### PR TITLE
Use the JDA instance directly, added a new set of UserPart's

### DIFF
--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/DiscordCommandManager.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/DiscordCommandManager.java
@@ -20,6 +20,7 @@ public class DiscordCommandManager implements CommandManager {
 
     public static final String MESSAGE_NAMESPACE = "MESSAGE";
     public static final String MEMBER_NAMESPACE = "MEMBER";
+    public static final String USER_NAMESPACE = "USER";
 
     private final CommandManager commandManager;
 

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/DiscordCommandManager.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/DiscordCommandManager.java
@@ -10,7 +10,7 @@ import me.fixeddev.commandflow.executor.Executor;
 import me.fixeddev.commandflow.input.InputTokenizer;
 import me.fixeddev.commandflow.translator.Translator;
 import me.fixeddev.commandflow.usage.UsageBuilder;
-import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.JDA;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,14 +23,14 @@ public class DiscordCommandManager implements CommandManager {
 
     private final CommandManager commandManager;
 
-    public DiscordCommandManager(JDABuilder client, String commandPrefix) {
+    public DiscordCommandManager(JDA client, String commandPrefix) {
         this(new SimpleCommandManager(), client, commandPrefix);
     }
 
-    public DiscordCommandManager(CommandManager commandManager, JDABuilder client, String commandPrefix) {
+    public DiscordCommandManager(CommandManager commandManager, JDA client, String commandPrefix) {
         this.commandManager = commandManager;
 
-        client.addEventListeners(new MessageListener(commandManager, commandPrefix));
+        client.addEventListener(new MessageListener(commandManager, commandPrefix));
 
         setAuthorizer(new DiscordAuthorizer());
         getTranslator().setProvider(new DiscordDefaultTranslationProvider());

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/DiscordDefaultTranslationProvider.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/DiscordDefaultTranslationProvider.java
@@ -7,5 +7,6 @@ public class DiscordDefaultTranslationProvider extends DefaultMapTranslationProv
     public DiscordDefaultTranslationProvider() {
         translations.put("unknown.member", "The member is unknown!");
         translations.put("unknown.channel", "The channel is unknown!");
+        translations.put("unknown.user", "The user is unknown!");
     }
 }

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/MessageListener.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/MessageListener.java
@@ -14,6 +14,7 @@ import me.fixeddev.commandflow.exception.NoPermissionsException;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.kyori.text.Component;
@@ -36,6 +37,7 @@ public class MessageListener extends ListenerAdapter {
     public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
 
         Member member = event.getMember();
+        User user = event.getAuthor();
         Message message = event.getMessage();
         TextChannel channel = event.getChannel();
 
@@ -63,6 +65,7 @@ public class MessageListener extends ListenerAdapter {
 
         namespace.setObject(Message.class, DiscordCommandManager.MESSAGE_NAMESPACE, message);
         namespace.setObject(Member.class, DiscordCommandManager.MEMBER_NAMESPACE, member);
+        namespace.setObject(User.class, DiscordCommandManager.USER_NAMESPACE, user);
 
         try {
             commandManager.execute(namespace, argumentLine);

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/factory/DiscordModule.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/factory/DiscordModule.java
@@ -6,14 +6,17 @@ import me.fixeddev.commandflow.discord.annotation.Sender;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
 
 public class DiscordModule extends AbstractModule {
 
     @Override
     public void configure() {
         bindFactory(Member.class, new MemberPartFactory());
+        bindFactory(User.class, new UserPartFactory());
         bindFactory(Message.class, new MessagePartFactory());
         bindFactory(TextChannel.class, new TextChannelPartFactory());
         bindFactory(new Key(Member.class, Sender.class), new MemberSenderPartFactory());
+        bindFactory(new Key(User.class, Sender.class), new UserSenderPartFactory());
     }
 }

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/factory/UserPartFactory.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/factory/UserPartFactory.java
@@ -1,0 +1,16 @@
+package me.fixeddev.commandflow.discord.factory;
+
+import me.fixeddev.commandflow.annotated.part.PartFactory;
+import me.fixeddev.commandflow.discord.part.UserPart;
+import me.fixeddev.commandflow.part.CommandPart;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+public class UserPartFactory implements PartFactory {
+
+    @Override
+    public CommandPart createPart(String name, List<? extends Annotation> modifiers) {
+        return new UserPart(name);
+    }
+}

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/factory/UserSenderPartFactory.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/factory/UserSenderPartFactory.java
@@ -1,0 +1,16 @@
+package me.fixeddev.commandflow.discord.factory;
+
+import me.fixeddev.commandflow.annotated.part.PartFactory;
+import me.fixeddev.commandflow.discord.part.UserSenderPart;
+import me.fixeddev.commandflow.part.CommandPart;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+public class UserSenderPartFactory implements PartFactory {
+
+    @Override
+    public CommandPart createPart(String name, List<? extends Annotation> modifiers) {
+        return new UserSenderPart(name);
+    }
+}

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/part/MemberPart.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/part/MemberPart.java
@@ -31,7 +31,6 @@ public class MemberPart implements ArgumentPart {
 
     @Override
     public List<? extends Member> parseValue(CommandContext context, ArgumentStack stack) throws ArgumentParseException {
-
         Message message = context.getObject(Message.class, DiscordCommandManager.MESSAGE_NAMESPACE);
         Guild guild = message.getTextChannel().getGuild();
 

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/part/UserPart.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/part/UserPart.java
@@ -1,0 +1,67 @@
+package me.fixeddev.commandflow.discord.part;
+
+import me.fixeddev.commandflow.CommandContext;
+import me.fixeddev.commandflow.discord.DiscordCommandManager;
+import me.fixeddev.commandflow.discord.utils.ArgumentsUtils;
+import me.fixeddev.commandflow.exception.ArgumentParseException;
+import me.fixeddev.commandflow.part.ArgumentPart;
+import me.fixeddev.commandflow.stack.ArgumentStack;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.kyori.text.TranslatableComponent;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
+public class UserPart implements ArgumentPart {
+
+    private final String name;
+
+    public UserPart(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public List<? extends User> parseValue(CommandContext context, ArgumentStack stack) throws ArgumentParseException {
+        Message message = context.getObject(Message.class, DiscordCommandManager.MESSAGE_NAMESPACE);
+        Guild guild = message.getTextChannel().getGuild();
+
+        String target = stack.next();
+
+        User user = null;
+
+        if (ArgumentsUtils.isValidSnowflake(target)) {
+            user = guild.getJDA().getUserById(target);
+        }
+
+        if (user == null && ArgumentsUtils.isValidTag(target)) {
+            user = guild.getJDA().getUserByTag(target);
+        }
+
+        if (user == null && ArgumentsUtils.isUserMention(target)) {
+            String id = target.substring(3, target.length() - 1);
+            user = guild.getJDA().getUserById(id);
+        }
+
+        if (user == null) {
+            ArgumentParseException exception = new ArgumentParseException(TranslatableComponent.of("unknown.user"));
+            exception.setArgument(this);
+
+            throw exception;
+        }
+
+        return Collections.singletonList(user);
+    }
+
+    @Override
+    public Type getType() {
+        return User.class;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/part/UserSenderPart.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/part/UserSenderPart.java
@@ -1,0 +1,37 @@
+package me.fixeddev.commandflow.discord.part;
+
+import me.fixeddev.commandflow.CommandContext;
+import me.fixeddev.commandflow.discord.DiscordCommandManager;
+import me.fixeddev.commandflow.exception.ArgumentParseException;
+import me.fixeddev.commandflow.exception.CommandException;
+import me.fixeddev.commandflow.part.CommandPart;
+import me.fixeddev.commandflow.stack.ArgumentStack;
+import net.dv8tion.jda.api.entities.User;
+import net.kyori.text.TranslatableComponent;
+
+public class UserSenderPart implements CommandPart {
+
+    private final String name;
+
+    public UserSenderPart(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void parse(CommandContext context, ArgumentStack stack) throws ArgumentParseException {
+        User user = context.getObject(User.class, DiscordCommandManager.USER_NAMESPACE);
+
+        if (user != null) {
+            context.setValue(this, user);
+
+            return;
+        }
+
+        throw new CommandException(TranslatableComponent.of("unknown.user"));
+    }
+}


### PR DESCRIPTION
The parameter 'JDABuilder' has been changed to 'JDA' from DiscordCommandManager, and new parts 'UserSenderPart' and 'UserPart' and their respective factory 'UserSenderPartFactory' and 'UserPartFactory' have been added